### PR TITLE
Updated schema name to be optional when using a registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ And then execute:
 
 ## Usage
 
-Thanks to Karafka's modular design, you only have to define a `parser` the moment you draw your consumer groups. 
+Thanks to Karafka's modular design, you only have to define a `parser` the moment you draw your consumer groups.
 
 ### Example with Schema Folder
 
@@ -63,6 +63,8 @@ App.consumer_groups.draw do
 end
 ```
 
+*Note: `schema_name` is not specifically required when using a schema registry, as the schema id is contained within the message, it can be passed in optionally if you are using one schema per topic*
+
 ## Note on contributions
 
 First, thank you for considering contributing to Karafka! It's people like you that make the open source community such a great community!
@@ -74,4 +76,3 @@ To check if everything is as it should be, we use [Coditsu](https://coditsu.io) 
 Coditsu will automatically check your work against our quality standards. You can find your commit check results on the [builds page](https://app.coditsu.io/karafka/commit_builds) of Karafka organization.
 
 [![coditsu](https://coditsu.io/assets/quality_bar.svg)](https://app.coditsu.io/karafka-avro/commit_builds)
-

--- a/lib/karafka/parsers/avro.rb
+++ b/lib/karafka/parsers/avro.rb
@@ -15,7 +15,7 @@ module Karafka
         @schemas_path = schemas_path
       end
 
-      def self.from_registry(schema_name)
+      def self.from_registry(schema_name = nil)
         raise ArgumentError, 'You have to specify registry_path first' if @registry_url.nil?
 
         Parser.new(AvroTurf::Messaging.new(registry_url: @registry_url), schema_name)

--- a/spec/karafka/parsers/avro_spec.rb
+++ b/spec/karafka/parsers/avro_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe Karafka::Parsers::Avro do
         expect(parser).to be_a(Karafka::Parsers::Avro::Parser)
         expect(parser.avro).to be_a(AvroTurf::Messaging)
       end
+
+      it 'returns a Parser instance when the schema name is not passed' do
+        parser = described_class.from_registry
+
+        expect(parser).to be_a(Karafka::Parsers::Avro::Parser)
+        expect(parser.avro).to be_a(AvroTurf::Messaging)
+      end
     end
   end
 end


### PR DESCRIPTION
I have updated the `schema_name` to be optional when using a Schema Registry, as the `schema_id` is contained within the Avro encoded message. The schema is returned from the registry based on this id when using `avro_turf`