### PR TITLE
jruby-9.3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.0'
           - '2.7'
           - '2.6'
+          - 'jruby-9.3.1.0'
         include:
           - ruby: '3.0'
             coverage: 'true'


### PR DESCRIPTION
Test against JRuby 9.3.x which is compatible with Ruby 2.6.x and stays in sync with C Ruby.