### PR TITLE
drop support for ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,8 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
-          - '2.6'
-          - 'jruby-9.3.1.0'
         include:
-          - ruby: '3.0'
+          - ruby: '3.1'
             coverage: 'true'
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Avro Parser changelog
 
 ## master
+- [#67](https://github.com/karafka/avro/pull/67) drop support for ruby 2.6
 - [#57](https://github.com/karafka/avro/pull/57) relax bundler dependency
 - [#56](https://github.com/karafka/avro/pull/56) drop support for ruby 2.5
 - [#9](https://github.com/karafka/avro/pull/9) drop support for ruby 2.3

--- a/karafka-avro-parser.gemspec
+++ b/karafka-avro-parser.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'avro_turf', '~> 0.8'
 


### PR DESCRIPTION
We are officially dropping support for ruby 2.6 because maintenance ends beginning of April 2022. More information in this post https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/. We also can't support JRuby because it is currently based on ruby 2.6.